### PR TITLE
Add manifests for ceph_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Deploy `ceph_export` on OpenShift
+
+This repository has the manifests to deploy [ceph_exporter][] on our OpenShift cluster. We are using a [custom image][] that includes code to generate a Ceph configuration from secrets available in the `openshift-storage` namespace.
+
+[ceph_exporter]: https://github.com/digitalocean/ceph_exporter
+[custom image]: https://github.com/OCP-on-NERC/ceph-exporter-image

--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ceph-exporter
+spec:
+  replicas: 1
+  template:
+    spec:
+      volumes:
+        - name: ceph-config
+          emptyDir: {}
+      containers:
+        - name: ceph-exporter
+          image: ghcr.io/ocp-on-nerc/ceph-exporter-image:v0.1.0
+          ports:
+            - name: metrics
+              containerPort: 9128
+          volumeMounts:
+            - name: ceph-config
+              mountPath: /etc/ceph
+          env:
+            - name: CEPH_MON_HOSTS
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-config
+                  key: mon_host
+            - name: CEPH_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-operator-creds
+                  key: userID
+            - name: CEPH_USERKEY
+              valueFrom:
+                secretKeyRef:
+                  name: rook-ceph-operator-creds
+                  key: userKey

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-storage
+
+commonLabels:
+  app: ceph-exporter
+
+resources:
+- deployment.yaml
+- service.yaml
+- servicemonitor.yaml
+
+configurations:
+  - transformers/commonLabels.yaml

--- a/base/service.yaml
+++ b/base/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ceph-exporter
+spec:
+  ports:
+    - port: 9128
+      protocol: TCP
+      name: metrics
+      targetPort: metrics

--- a/base/servicemonitor.yaml
+++ b/base/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: ceph-exporter
+spec:
+  endpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      interval: 5m
+
+      relabelings:
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        sourceLabels:
+        - service
+        targetLabel: instance

--- a/base/transformers/commonLabels.yaml
+++ b/base/transformers/commonLabels.yaml
@@ -1,0 +1,9 @@
+# ServiceMonitor is a CRD, so Kustomize doesn't know about it by default.
+# This configuration tells Kustomize where to place labels defined with
+# the `commonLabels` setting in `kustomization.yaml`.
+commonLabels:
+- path: spec/selector/matchLabels
+  create: true
+  group: monitoring.coreos.com
+  version: v1
+  kind: ServiceMonitor

--- a/overlays/nerc-ocp-infra/kustomization.yaml
+++ b/overlays/nerc-ocp-infra/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base


### PR DESCRIPTION
Add the manifests necessary to deploy `ceph_exporter` [1] and expose the metrics
to Prometheus.

Part of: ocp-on-nerc/operations#39
Part of: ocp-on-nerc/operations#102

[1]: https://github.com/digitalocean/ceph_exporter
